### PR TITLE
Add fit-to-page boolean option

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -523,7 +523,8 @@ attributes["Job Template"] = {
 	"y-image-position":								keyword,
 	"y-image-shift":								integer,
 	"y-side1-image-shift":							integer,
-	"y-side2-image-shift":							integer
+	"y-side2-image-shift":							integer,
+	"fit-to-page":						boolean
 };
 attributes["Operation"] = {
 	"attributes-charset":							charset,


### PR DESCRIPTION
Extend job-attributes-tag options, this option allow to fit printing at print area. http://www.cups.org/documentation.php/options.html#FIT_TO_PAGE

Small issue, when fit-to-page turned on some jobs(or printers) rotate printing in 180 Deg...
