### PR TITLE
Add support for node-webkit

### DIFF
--- a/lib/ipputil.js
+++ b/lib/ipputil.js
@@ -16,7 +16,7 @@ exports.xref = xref;
 
 exports.extend  = function extend(destination, source) {
 	for(var property in source) {
-		if (source[property] && source[property].constructor === Object) {
+		if (source[property] && (typeof source[property] === 'object' && !(source[property] instanceof Buffer))) {
 			destination[property] = destination[property] || {};
 			extend(destination[property], source[property]);
 		}


### PR DESCRIPTION
The check "source[property].constructor === Object" always comes back false causing the source not to be merged into the destination correctly. My fix does allow extended objects through (like Buffer... hence the second check) were it wouldn't before. I would consider it a good thing... but maybe it was originally intended to block those?
