### PR TITLE
Fix HTTPS support, allow self-signed certificates

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -127,7 +127,7 @@ module.exports = function(buf) {
 				read(length);
 				return readCollection();
 
-			case tags.no-value:
+			case tags['no-value']:
 			default:
 				debugger;
 				return module.exports.handleUnknownTag(tag, name, length, read)

--- a/lib/request.js
+++ b/lib/request.js
@@ -22,7 +22,19 @@ module.exports = function(opts, buffer, cb){
 	if(opts.protocol==="ipp:")
 		opts.protocol="http:";
 
-	var req = (opts.protocol==="https" ? https : http).request(opts, function(res){
+	if(opts.protocol==="ipps:")
+		opts.protocol="https:";
+
+	var agent = http;
+	if(opts.protocol==="https:"){
+		agent = https;
+		// Allow self-signet certs
+		opts.rejectUnauthorized = false;
+		opts.requestCert = true;
+		opts.agent = false;
+	}
+
+	var req = agent.request(opts, function(res){
 //		console.log('STATUS: ' + res.statusCode);
 //		console.log('HEADERS: ' + JSON.stringify(res.headers));
 		switch(res.statusCode){

--- a/lib/request.js
+++ b/lib/request.js
@@ -25,16 +25,7 @@ module.exports = function(opts, buffer, cb){
 	if(opts.protocol==="ipps:")
 		opts.protocol="https:";
 
-	var agent = http;
-	if(opts.protocol==="https:"){
-		agent = https;
-		// Allow self-signet certs
-		opts.rejectUnauthorized = false;
-		opts.requestCert = true;
-		opts.agent = false;
-	}
-
-	var req = agent.request(opts, function(res){
+	var req = (opts.protocol==="https:" ? https : http).request(opts, function(res){
 //		console.log('STATUS: ' + res.statusCode);
 //		console.log('HEADERS: ' + JSON.stringify(res.headers));
 		switch(res.statusCode){

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 
 var http = require('http'),
-	https = require('http'),
+	https = require('https'),
 	url = require('url'),
 	parse = require('./parser');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ipp",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "Internet Printing Protocol (IPP) for nodejs",
 	"keywords": ["ipp", "print", "printing"],
 	"homepage": "http://github.com/williamkapke/ipp",


### PR DESCRIPTION
Hey there!

First of all thank you for the fantastic library, it saved me tons of time!
In my particular use case I had to print over ipps, and I encountered with this error:
```javascript
Error: Protocol "https:" not supported. Expected "http:".
    at new ClientRequest (_http_client.js:52:11)
    at Object.exports.request (http.js:31:10)
    at module.exports (api/node_modules/ipp/lib/request.js:25:53)
    at Object.Printer.execute (api/node_modules/ipp/lib/printer.js:51:3)
    ...
```
The cause of the problem was a typo in [lib/request.js, line 25](https://github.com/williamkapke/ipp/blob/master/lib/request.js#L25). Missing colon after `https`.

I've fixed it, but also encountered with self-signed certificate problem, because my printer has it, so I had to add some flags to omit it. I guess it's [widely used approach](https://support.microsoft.com/en-us/kb/2021626). But may be it makes sense to make these flags optional for the sake of security?

Thanks,
Viktor