### PR TITLE
Handle errors for unexpected http status codes

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -30,19 +30,21 @@ module.exports = function(opts, buffer, cb){
 //		console.log('HEADERS: ' + JSON.stringify(res.headers));
 		switch(res.statusCode){
 			case 100:
-				//TODO: finish
+				if(opts.headers['Expect'] !== '100-Continue' || typeof opts.continue !== "function"){
+					cb(new IppResponseError(res.statusCode));
+				}
 				return console.log("100 Continue");
 			case 200:
 				return readResponse(res, cb);
 			default:
-				//TODO: finish
+				cb(new IppResponseError(res.statusCode));
 				return console.log(res.statusCode, "response");
 		}
 	});
 	req.on('error', function(err) {
 		cb(err);
 	});
-	if(opts.headers['Expect'] = '100-Continue' && typeof opts.continue=== "function"){
+	if(opts.headers['Expect'] === '100-Continue' && typeof opts.continue=== "function"){
 		req.on('continue', function() {
 			opts.continue(req);
 		});
@@ -62,3 +64,12 @@ function readResponse(res, cb){
 		cb(null, response);
 	});
 }
+
+function IppResponseError(statusCode, message) {
+  this.name = 'IppResponseError';
+  this.statusCode = statusCode;
+  this.message = message || 'Received unexpected response status ' + statusCode + ' from the printer';
+  this.stack = (new Error()).stack;
+}
+IppResponseError.prototype = Object.create(Error.prototype);
+IppResponseError.prototype.constructor = IppResponseError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ipp",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Internet Printing Protocol (IPP) for nodejs",
 	"keywords": ["ipp", "print", "printing"],
 	"homepage": "http://github.com/williamkapke/ipp",


### PR DESCRIPTION
Currently the library will not trigger the callback when a http request fails. I've often observed 204 status codes when trying to print to my Brother HL-2170W printer while it is busy. This change will allow an application to respond to such errors.