### PR TITLE
Removed some errors in serializer

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -13,7 +13,7 @@ function random(){
 }
 
 module.exports = function serializer(msg){
-	var buf = new Buffer(1024);
+	var buf = new Buffer(10240);
 	var position = 0;
 	function write1(val){
 		buf.writeUInt8(val, position);
@@ -35,14 +35,14 @@ module.exports = function serializer(msg){
 	}
 	var special = {'attributes-charset':1, 'attributes-natural-language':2};
 	var groupmap = {
-		"job-attributes-tag":				'Job Template',
-		'operation-attributes-tag':			'Operation',
-		'printer-attributes-tag':			'Printer Description',
-		"unsupported-attributes-tag":		'',//??
-		"subscription-attributes-tag":		'Subscription Description',
+		"job-attributes-tag":	               ['Job Template', 'Job Description'],
+		'operation-attributes-tag':          'Operation',
+		'printer-attributes-tag':            'Printer Description',
+		"unsupported-attributes-tag":        '',//??
+		"subscription-attributes-tag":       'Subscription Description',
 		"event-notification-attributes-tag": 'Event Notifications',
-		"resource-attributes-tag":			'',//??
-		"document-attributes-tag":			'Document Description'
+		"resource-attributes-tag":           '',//??
+		"document-attributes-tag":           'Document Description'
 	};
 	function writeGroup(tag){
 		var attrs = msg[tag];
@@ -58,7 +58,15 @@ module.exports = function serializer(msg){
 		});
 	}
 	function attr(group, name, obj){
-		var syntax = attributes[group][name];
+		var syntax;
+
+    if (Array.isArray(group)) {
+			group.forEach((grp) => {
+			  syntax = syntax || attributes[grp][name];
+			});
+		} else {
+			syntax = attributes[group][name];
+		}
 		if(!syntax) throw "Unknown attribute: " + name;
 
 		var value = obj[name];
@@ -95,24 +103,24 @@ module.exports = function serializer(msg){
 		switch(array.alts){
 			case 'keyword,name':
 			case 'keyword,name,novalue':
-				if(value===null && array.lookup['novalue']) return array.lookup['no-value'];
+				if(value===null && array.lookup['novalue']) return array.lookup['novalue'];
 				return ~keywords[name].indexOf(value)? array.lookup.keyword : array.lookup.name;
 			case 'integer,rangeOfInteger':
 				return Array.isArray(value)? array.lookup.rangeOfInteger : array.lookup.integer;
 			case 'dateTime,novalue':
-				return !IsNaN(date.parse(value))? array.lookup.dateTime : array.lookup['no-value'];
+				return !IsNaN(date.parse(value))? array.lookup.dateTime : array.lookup['novalue'];
 			case 'integer,novalue':
-				return !IsNaN(value)? array.lookup.integer : array.lookup['no-value'];
+				return !IsNaN(value)? array.lookup.integer : array.lookup['novalue'];
 			case 'name,novalue':
-				return value!==null? array.lookup.name : array.lookup['no-value'];
+				return value!==null? array.lookup.name : array.lookup['novalue'];
 			case 'novalue,uri':
-				return value!==null? array.lookup.uri : array.lookup['no-value'];
+				return value!==null? array.lookup.uri : array.lookup['novalue'];
 			case 'enumeration,unknown':
-				return enums[name][value]? array.lookup['enum'] : array.lookup.unknown;
+				return enums[name][value]? array.lookup['enumeration'] : array.lookup.unknown;
 			case 'enumeration,novalue':
-				return value!==null? array.lookup['enum'] : array.lookup['no-value'];
+				return value!==null? array.lookup['enumeration'] : array.lookup['novalue'];
 			case 'collection,novalue':
-				return value!==null? array.lookup['enum'] : array.lookup['no-value'];
+				return value!==null? array.lookup['enumeration'] : array.lookup['novalue'];
 			default:
 				throw "Unknown atlernates";
 		}
@@ -183,7 +191,7 @@ module.exports = function serializer(msg){
 			case tags.begCollection:
 				write2(0);//empty value
 				return writeCollection(value, submembers);
-			
+
 			case tags["no-value"]:
 				//empty value? I can't find where this is defined in any spec.
 				return write2(0);
@@ -228,7 +236,7 @@ module.exports = function serializer(msg){
 	//TODO... add the others
 
 	write1(0x03);//end
-	
+
 
 	if(!msg.data)
 		return buf.slice(0, position);

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -58,15 +58,12 @@ module.exports = function serializer(msg){
 		});
 	}
 	function attr(group, name, obj){
-		var syntax;
+		var groupName = Array.isArray(group)
+			? group.find((grp) => { return attributes[grp][name] })
+			: group;
+		if(!groupName) throw "Unknown attribute: " + name;
 
-    if (Array.isArray(group)) {
-			group.forEach((grp) => {
-			  syntax = syntax || attributes[grp][name];
-			});
-		} else {
-			syntax = attributes[group][name];
-		}
+		var syntax = attributes[groupName][name];
 		if(!syntax) throw "Unknown attribute: " + name;
 
 		var value = obj[name];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ipp",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "Internet Printing Protocol (IPP) for nodejs",
 	"keywords": ["ipp", "print", "printing"],
 	"homepage": "http://github.com/williamkapke/ipp",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"description": "Internet Printing Protocol (IPP) for nodejs",
 	"keywords": ["ipp", "print", "printing"],
 	"homepage": "http://github.com/williamkapke/ipp",
+	"publishConfig": {
+    "registry": "http://plossys.artifactoryonline.com/plossys/api/npm/npm-local"
+  },
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/williamkapke/ipp.git"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
 	"description": "Internet Printing Protocol (IPP) for nodejs",
 	"keywords": ["ipp", "print", "printing"],
 	"homepage": "http://github.com/williamkapke/ipp",
-	"publishConfig": {
-    "registry": "http://plossys.artifactoryonline.com/plossys/api/npm/npm-local"
-  },
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/williamkapke/ipp.git"


### PR DESCRIPTION
Hi, when using serializer I run into some problems and fixed them.

- line 16: 1k buffer is quite small. A response to e.g. 'Get-Printer-Attributes' operation may not fit into so i increased the buffer size to 10k.

- line 38: according to RFC 2910 section 3.3 the 'job-attributes-tag' is part of the Job Template and the Job Object group. I made the mapping an array and added in 'attr' a loop to find the syntax. For example thats necessary for the response to a 'Print-Job' request (RFC 2911 section 3.2.1.2) which needs job-id, job-uri and job-state in a job object attributes group.

- 'resolveAlternates' function: the lookup properties got the name of the callee in 'attributes.js'. Thats 'enumeration' and 'novalue' instead of 'enum' and 'no-value'.