### PR TITLE
Use nameWithoutLanguage after value in collection

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -208,7 +208,7 @@ module.exports = function serializer(msg){
 			write1(tags.memberAttrName)
 			write2(0)//empty name
 			writeValue(tags.memberAttrName, key);
-			write1(tags.memberAttrName)
+			write1(tags.nameWithoutLanguage)
 			write2(0)//empty name
 			writeValue(tag, subvalue, subsyntax.members);
 		});


### PR DESCRIPTION
This resolves an issue with setting the tray to print from with ipp.
Printers I have tested on will not recognize the media-col settings
using the current version of this library.

I haven't dug far enough into the spec to know whether this is correct,
but this commit matches output of ipptool when setting a media-source
within the media-col collection. After the change I am able to set the
tray when printing.

For example, the request body generated by the following ipptool file
will have a "B" (0x42) after "media-source" as opposed to the current
"J" (0x4a) generated by lib/serializer.js.

ipptool input file:
```
{
  # The name of the test
  NAME "Print PostScript File"

  # The request to send
  OPERATION Print-Job
  GROUP operation-attributes-tag
  ATTR charset attributes-charset utf-8
  ATTR language attributes-natural-language en
  ATTR uri printer-uri $uri
  ATTR name requesting-user-name $user
  FILE testfile.ps

  GROUP job-attributes-tag
  ATTR collection media-col {
    MEMBER name media-source auto
  }

  # The response to expect
  STATUS successful-ok
  EXPECT job-id OF-TYPE integer WITH-VALUE >0
  EXPECT job-uri OF-TYPE uri
}
```
Portion from ipptool output:
```
media-sourceB\u0000\u0000\u0000\u0004auto7
```

Portion from lib/serializer.js output (prior to this commit):
```
media-sourceJ\u0000\u0000\u0000\u0004auto7
```