### PR TITLE
allow the module to compile using webpack

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -12,59 +12,59 @@ var tags = require('./tags');
 
 function text(max){
   if(!max) max = 1023;
-  return { type:arguments.callee.name, max: max };
+  return { type:'text', max: max };
 }
 function integer(min,max){
   if(max==MAX || max===undefined) max = 2147483647;
   if(min===undefined) min = -2147483648;
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], min: min, max: max };
+  return { type:'integer', tag:tags['integer'], min: min, max: max };
 }
 function rangeOfInteger(min,max){
   if(max==MAX || max===undefined) max = 2147483647;
   if(min===undefined) min = -2147483648;
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], min: min, max: max };
+  return { type:'rangeOfInteger', tag:tags['rangeOfInteger'], min: min, max: max };
 }
 function boolean(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name] };
+  return { type:'boolean', tag:tags['boolean'] };
 }
 function charset(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], max: 63 };
+  return { type:'charset', tag:tags['charset'], max: 63 };
 }
 function keyword(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], min:1, max:1023 };
+  return { type:'keyword', tag:tags['keyword'], min:1, max:1023 };
 }
 function naturalLanguage(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], max: 63 };
+  return { type:'naturalLanguage', tag:tags['naturalLanguage'], max: 63 };
 }
 function dateTime(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name] };
+  return { type:'dateTime', tag:tags['dateTime'] };
 }
 function mimeMediaType(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], max: 255 };
+  return { type:'mimeMediaType', tag:tags['mimeMediaType'], max: 255 };
 }
 function uri(max){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], max: max||1023 };
+  return { type:'uri', tag:tags['uri'], max: max||1023 };
 }
 function uriScheme(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], max: 63 };
+  return { type:'uriScheme', tag:tags['uriScheme'], max: 63 };
 }
 function enumeration(){
-  return { type:arguments.callee.name, tag:tags['enum'] };
+  return { type:'enumeration', tag:tags['enum'] };
 }
 function resolution(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name] };
+  return { type:'resolution', tag:tags['resolution'] };
 }
 function unknown(){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name] };
+  return { type:'unknown', tag:tags['unknown'] };
 }
 function name(max){
-  return { type:arguments.callee.name, max: max||1023 };
+  return { type:'name', max: max||1023 };
 }
 function novalue(){
-  return { type:arguments.callee.name, tag:tags['no-value'] };
+  return { type:'novalue', tag:tags['no-value'] };
 }
 function octetString(max){
-  return { type:arguments.callee.name, tag:tags[arguments.callee.name], max: max||1023 };
+  return { type:'octetString', tag:tags['octetString'], max: max||1023 };
 }
 
 //Some attributes allow alternate value syntaxes.
@@ -97,7 +97,6 @@ const isDeferred = function (type) {
 // In IPP, "1setOf" just means "Array"... but it must 1 or more items
 // In javascript, functions can't start with a number- so let's just use...
 function setof(type){
-	console.log('TYPE:', type);
   if(isDeferred(type)){
     return createDeferred(function(){
       type = type();

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -74,7 +74,7 @@ function octetString(max){
 function _(arg1, arg2, arg3){
   var args = Array.prototype.slice.call(arguments);
   args.lookup = {};
-  function deferred(){
+  const deferred = createDeferred(function(){
     args.forEach(function(a,i){
       if(typeof a==="function")
         args[i] = a();
@@ -82,21 +82,30 @@ function _(arg1, arg2, arg3){
     });
     args.alts = Object.keys(args.lookup).sort().join();
     return args;
-  }
-  return args.some(function(a){ return a.name==="deferred" }) ? deferred : deferred();
+  })
+  return args.some(function(a){ return isDeferred(a) }) ? deferred : deferred();
+}
+const createDeferred = function (deferred) {
+	deferred.isDeferred = true;
+	return deferred;
+}
+
+const isDeferred = function (type) {
+	return typeof type === "function" && type.isDeferred
 }
 
 // In IPP, "1setOf" just means "Array"... but it must 1 or more items
 // In javascript, functions can't start with a number- so let's just use...
 function setof(type){
-  if(type.name === "deferred"){
-    return function deferred(){
+	console.log('TYPE:', type);
+  if(isDeferred(type)){
+    return createDeferred(function(){
       type = type();
       type.setof=true;
       return type;
-    }
+    })
   }
-  if(typeof type === "function" && type.name != "deferred"){
+  if(typeof type === "function" &&  !isDeferred(type)){
     type = type();
   }
   type.setof=true;
@@ -110,24 +119,24 @@ function collection(group, name){
     return { type: "collection", tag:tags.begCollection }
 
   if(typeof group === "string"){
-    return function deferred(){
-      return {
-        type: "collection",
-        tag:tags.begCollection,
-        members: attributes[group][name].members
-      }
-    }
+    return createDeferred(function(){
+	      return {
+	        type: "collection",
+	        tag:tags.begCollection,
+	        members: attributes[group][name].members
+				}
+    });
   }
   var defer = Object.keys(group).some(function(key){
-    return group[key].name==="deferred"
+    return isDeferred(group[key])
   })
-  function deferred(){
+  const deferred = createDeferred(function(){
     return {
       type: "collection",
       tag:tags.begCollection,
       members: resolve(group)
     }
-  }
+  })
   return defer? deferred : deferred();
 }
 

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -73,6 +73,7 @@ module.exports = function serializer(msg){
 		if(!groupName) throw "Unknown attribute: " + name;
 
 		var syntax = attributes[groupName][name];
+
 		if(!syntax) throw "Unknown attribute: " + name;
 
 		var value = obj[name];
@@ -204,7 +205,7 @@ module.exports = function serializer(msg){
 
 			default:
 				debugger;
-				console.log(tag, "not handled");
+				console.error(tag, "not handled");
 		}
 	}
 	function writeCollection(value, members){


### PR DESCRIPTION
The original version contains statically defined function names and therefore are hard to compile using, for instance, webpack. 
the following changes enables the support.