### PR TITLE
Do not encode data, keep as buffer

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -184,7 +184,7 @@ module.exports = function(buf) {
 	readGroups();
 
 	if(position<buf.length)
-		obj.data = buf.toString(encoding, position);
+		obj.data = buf.slice(position);
 
 	return obj;
 };


### PR DESCRIPTION
I'm using the ipp module to download print documents. This is one of the seldom cases where the module fills `obj.data`.
Unfortunately the data was corrupted and eg. a PDF file couldn't be downloaded correctly.

Keeping the data in a buffer solves the problem.
Instead of encode the data with the encoding for the IPP header I just slice the buffer at the position after the IPP header.
