### PR TITLE
Update serializer.js

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -67,9 +67,16 @@ module.exports = function serializer(msg){
 		});
 	}
 	function attr(group, name, obj){
-		var groupName = Array.isArray(group)
-			? group.find( function (grp) { return attributes[grp][name] })
-			: group;
+		var groupName = group;
+		
+		if(Array.isArray(group)) {
+			group.forEach(function(grp) {
+				if(attributes[grp] && attributes[grp][name]) {
+					groupName = grp;
+				}
+			});
+		}
+
 		if(!groupName) throw "Unknown attribute: " + name;
 
 		var syntax = attributes[groupName][name];


### PR DESCRIPTION
`group.find` not working properly with node 4.4.4 and cause -for some reason- the `groupName` to be `-1`
I changed it to `.forEach` instead which works fine now.