### PR TITLE
Fix: Error: getaddrinfo -3008 (Ubuntu 16.04)

### DIFF
--- a/examples/findPrinters.js
+++ b/examples/findPrinters.js
@@ -1,6 +1,8 @@
 
 var mdns = require('mdns'),
 	browser  = mdns.createBrowser(mdns.tcp('ipp'));
+	
+mdns.Browser.defaultResolverSequence[1] = 'DNSServiceGetAddrInfo' in mdns.dns_sd ? mdns.rst.DNSServiceGetAddrInfo() : mdns.rst.getaddrinfo({families:[4]}); 
 
 browser.on('serviceUp', function (rec) {
 	console.log(rec.name, 'http://'+rec.host+':'+rec.port+'/'+rec.txtRecord.rp);


### PR DESCRIPTION
$ node examples/findPrinters.js
*** WARNING *** The program 'node' uses the Apple Bonjour compatibility layer of Avahi.
*** WARNING *** Please fix your application to use the native API of Avahi!
*** WARNING *** For more information see <http://0pointer.de/avahi-compat?s=libdns_sd&e=node>
*** WARNING *** The program 'node' called 'DNSServiceRegister()' which is not supported (or only supported partially) in the Apple Bonjour compatibility layer of Avahi.
*** WARNING *** Please fix your application to use the native API of Avahi!
*** WARNING *** For more information see <http://0pointer.de/avahi-compat?s=libdns_sd&e=node&f=DNSServiceRegister>
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo -3008
    at errnoException (../mdns/lib/resolver_sequence_tasks.js:199:11)
    at getaddrinfo_complete (../node_modules/mdns/lib/resolver_sequence_tasks.js:112:10)
    at GetAddrInfoReqWrap.oncomplete (../node_modules/mdns/lib/resolver_sequence_tasks.js:120:9)

Ref: https://github.com/agnat/node_mdns/issues/130