### PR TITLE
fix serializer for rangeOfInteger

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -147,8 +147,8 @@ module.exports = function serializer(msg){
 
 			case tags.rangeOfInteger:
 				write2(0x0008);
-				write4(value[0]);
-				write4(value[1]);
+				write4(value.min);
+				write4(value.max);
 				return;
 
 			case tags.resolution:


### PR DESCRIPTION
A small fix serializer.js to encode rangeOfInteger, using object which is created by the function rangeOfInteger which was defined in attributes.js