### PR TITLE
Add support for "output-mode"

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -244,6 +244,7 @@ attributes["Document Template"] = {
   "media-input-tray-check":                       _(keyword, name),
   "number-up":                                    integer(1,MAX),
   "orientation-requested":                        enumeration,
+  "output-mode":                                  keyword,
   "overrides":                                    setof(collection({
     //Any Document Template attribute (TODO)
 		"document-copies":                            setof(rangeOfInteger),
@@ -494,6 +495,7 @@ attributes["Job Template"] = {
   "orientation-requested":                        enumeration,
   "output-bin":                                   _(keyword, name),
   "output-device":                                name(127),
+  "output-mode":                                  keyword,
   "overrides":                                    setof(collection({
     //Any Job Template attribute (TODO)
 		"document-copies":                            setof(rangeOfInteger),
@@ -764,6 +766,8 @@ attributes["Operation"] = {
   "output-bin-default":                           _(keyword, name),
   "output-bin-supported":                         setof(_(keyword, name)),
   "output-device-supported":                      setof(name(127)),
+  "output-mode-default":                          keyword,
+  "output-mode-supported":                        setof(keyword),
   "overrides-supported":                          setof(keyword),
   "page-delivery-default":                        keyword,
   "page-delivery-supported":                      setof(keyword),

--- a/lib/keywords.js
+++ b/lib/keywords.js
@@ -1183,6 +1183,21 @@ keywords["output-bin-default"] = keyword_name(
 keywords["output-bin-supported"] = setof_keyword_name(
   keywords["output-bin"]
 );
+keywords["output-mode"] = keyword([
+  "auto",
+  "bi-level",
+  "color",
+  "highlight",
+  "monochrome",
+  "process-bi-level",
+  "process-monochrome"
+]);
+keywords["output-mode-default"] = keyword(
+  keywords["output-mode"]
+);
+keywords["output-mode-supported"] = setof_keyword(
+  keywords["output-mode"]
+);
 keywords["page-delivery"] = keyword([
   "reverse-order-face-down",
   "reverse-order-face-up",


### PR DESCRIPTION
This PR is to add "output-mode" to the keywords and attributes.

There are some printers that do not support the job-creation-attribute "print-color-mode". However the printer does support the attribute "output-mode".

From what I can gather, these two attributes are the same. For some reason or another the printer manufacturer decided not to follow the standard with "print-color-mode".

Currently if you send a "Print-Job" with "output-mode" as a attribute for the "job-attributes-tag" the IPP serializer throws an error: "Unknown attribute: output-mode"

To get around this error you can not supply the "output-mode" attribute and the printer will print in what ever color is default, in the particular case the default is set to color.
