### PR TITLE
Event Notifications and Subscriptions (rfc3995)

### DIFF
--- a/examples/Create-Printer-Subscriptions.js
+++ b/examples/Create-Printer-Subscriptions.js
@@ -1,0 +1,23 @@
+const ipp = require('../ipp');
+
+// Create subscription to events from all of the printers registered on a cups server.
+const printerUri = 'http://localhost:631/printers';
+
+(async function getSubscriptions() {
+  const printer = new ipp.Printer(printerUri);
+  var msg = {
+    'operation-attributes-tag': {
+      'requesting-user-name': '',
+    },
+    'subscription-attributes-tag': {
+      'notify-recipient-uri': 'http://recipient-uri',
+      'notify-events': ['all'],
+      // Subscription duration in seconds. Default value is 86400 (1 day). 0 means indefinite length subscription.
+      'notify-lease-duration': 0,
+    },
+  };
+  printer.execute('Create-Printer-Subscriptions', msg, function (err, res) {
+    if (err) console.log(err);
+    console.log(res);
+  });
+})();

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -54,7 +54,7 @@ module.exports = function serializer(msg){
 		'operation-attributes-tag':          'Operation',
 		'printer-attributes-tag':            'Printer Description',
 		"unsupported-attributes-tag":        '',//??
-		"subscription-attributes-tag":       'Subscription Description',
+		"subscription-attributes-tag":       ['Subscription Description', 'Subscription Template'],
 		"event-notification-attributes-tag": 'Event Notifications',
 		"resource-attributes-tag":           '',//??
 		"document-attributes-tag":           'Document Description'
@@ -246,6 +246,7 @@ module.exports = function serializer(msg){
 	writeGroup('job-attributes-tag');
 	writeGroup('printer-attributes-tag');
 	writeGroup('document-attributes-tag');
+  writeGroup('subscription-attributes-tag');
 	//TODO... add the others
 
 	write1(0x03);//end


### PR DESCRIPTION
These changes allow to create Printers and Jobs subscriptions in compliance with rfc3995. Which is an optional extension to ipp1.1.
I've also added an example script for printer subscription.
I have not checked compliance thoroughly, but tested it for printer and job subscriptions.

I'm currently working on a public printing system and have a lot of printers registered in CUPS server. This feature allows to send specified events to the designated api server and is useful to me.

I would be grateful for any response according this PR.