### PR TITLE
feat: proper handling of invalid IPP responses.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -59,9 +59,13 @@ function readResponse(res, cb){
 		chunks.push(chunk);
 	});
 	res.on('end', function(){
-		var response = parse(Buffer.concat(chunks, length));
-		delete response.operation;
-		cb(null, response);
+		try{
+			var response = parse(Buffer.concat(chunks, length));
+			delete response.operation;
+			cb(null, response);	
+		} catch (error){
+			cb(error, null);	
+		}
 	});
 }
 


### PR DESCRIPTION
Currently we are observing that one specific IPP printer occasionally sends an completly empty response. Although we think this is an implementation problem on the printer side this crashes our process (node.js 12ff).

I suggest to add a simple try/catch to handle this kind of problem in the response processing.